### PR TITLE
New mapbox gem and style

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'compass-rails', '2.0.4'
 gem 'pg'
 gem 'activerecord-postgis-adapter'
 gem 'auto_increment'
-gem 'mapbox-rails'
+gem 'mapbox-rails', '2.3.0'
 
 gem 'typekit-rails'
 

--- a/app/assets/javascripts/backbone/apps/map/show/show_view.js.coffee
+++ b/app/assets/javascripts/backbone/apps/map/show/show_view.js.coffee
@@ -486,13 +486,7 @@
 
     L.mapbox.accessToken = 'pk.eyJ1IjoiZWxpamFobWVla3MiLCJhIjoiYXlPRmNObyJ9.wnIqLHTkEEAVVT-ihW8BjQ'
 
-    # mapbox light basemap, in progress
-    l_mblight = L.tileLayer(
-        'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
-        id: 'elijahmeeks/ck6cspw6d07ne1ipkqy6czvut',
-        attribution: 'Mapbox',
-        accessToken: L.mapbox.accessToken
-        });
+    l_mblight = L.mapbox.styleLayer('mapbox://styles/elijahmeeks/ck6cspw6d07ne1ipkqy6czvut');
 
     # OSM base layer
     l_osm = L.tileLayer(


### PR DESCRIPTION
This accomplishes the "Mapbox.js implementation" of the migration of the Modern basemap from the soon-to-be deprecated Classic style API to a style served with the "modern" Static Tiles API, see docs at
https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/

Note that it requires an upgrade of the `mapbox-rails` gem, which needs to be tested on `stage`.

