### PR TITLE
Load overlay layers as Leaflet to preserve transparency

### DIFF
--- a/app/assets/javascripts/backbone/apps/map/show/show_view.js.coffee
+++ b/app/assets/javascripts/backbone/apps/map/show/show_view.js.coffee
@@ -494,27 +494,32 @@
       { detectRetina: true }
       );
 
-    l_indicator = L.mapbox.tileLayer(
-        'elijahmeeks.5s7vzgi4',
-        # 'elijahmeeks.gqd89536',
-        L.mapbox.accessToken, {
-        attribution: 'Indicator (1880)',
-        detectRetina: true
-        });
+    l_indicator = L.tileLayer(
+         'https://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png', {
+         tileSize: 256,
+         id: 'elijahmeeks.5s7vzgi4',
+         #id: 'elijahmeeks.gqd89536',
+         attribution: 'Indicator (1880)',
+         accessToken: L.mapbox.accessToken,
+         detectRetina: true
+         });
 
-    l_bowles = L.mapbox.tileLayer(
-        'elijahmeeks.95vtr2c4',
-        # 'elijahmeeks.36cac3di',
-        L.mapbox.accessToken, {
-        attribution: 'Bowles (1783)',
-        detectRetina: true
-        });
+    l_bowles = L.tileLayer(
+         'https://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png', {
+         tileSize: 256,
+         id: 'elijahmeeks.95vtr2c4',
+         #id: 'elijahmeeks.36cac3di',
+         attribution: 'Bowles (1783)',
+         accessToken: L.mapbox.accessToken,
+         detectRetina: true
+         });
 
-
-    l_taylor = L.mapbox.tileLayer(
-        'elijahmeeks.1pr88bpk',
-        # 'elijahmeeks.7dd6ynaj',
-        L.mapbox.accessToken, {
-        attribution: 'Taylor (1723)',
-        detectRetina: true
-        });
+    l_taylor = L.tileLayer(
+         'https://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png', {
+         tileSize: 256,
+         id: 'elijahmeeks.1pr88bpk',
+         #id: 'elijahmeeks.7dd6ynaj',
+         attribution: 'Taylor (1723)',
+         accessToken: L.mapbox.accessToken,
+         detectRetina: true
+         });


### PR DESCRIPTION
Loading the historical map overlay layers as Mapbox layers using the updated `mapbox-rails` gem, which is needed to use a modern Mapbox style layer for the basemap (instead of the old and soon-to-be-defunct "classic" basemap style), results in black borders appearing where the transparent PNG pixels were present in the source images. Switching these layers to load as Leaflet layers instead solves this problem, though the reasons for this are not immediately obvious.