### PR TITLE
Mapbox update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'compass-rails', '2.0.4'
 gem 'pg'
 gem 'activerecord-postgis-adapter'
 gem 'auto_increment'
-gem 'mapbox-rails'
+gem 'mapbox-rails', '2.3.0'
 
 gem 'typekit-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mapbox-rails (1.6.1.1)
+    mapbox-rails (2.3.0)
     mime-types (2.99)
     mimemagic (0.3.1)
     mini_portile2 (2.0.0)
@@ -358,7 +358,7 @@ DEPENDENCIES
   font-awesome-rails
   jbuilder (~> 2.0)
   jquery-rails
-  mapbox-rails
+  mapbox-rails (= 2.3.0)
   paperclip!
   pg
   rabl

--- a/app/assets/javascripts/backbone/apps/map/show/show_view.js.coffee
+++ b/app/assets/javascripts/backbone/apps/map/show/show_view.js.coffee
@@ -494,27 +494,32 @@
       { detectRetina: true }
       );
 
-    l_indicator = L.mapbox.tileLayer(
-        'elijahmeeks.5s7vzgi4',
-        # 'elijahmeeks.gqd89536',
-        L.mapbox.accessToken, {
-        attribution: 'Indicator (1880)',
-        detectRetina: true
-        });
+    l_indicator = L.tileLayer(
+         'https://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png', {
+         tileSize: 256,
+         id: 'elijahmeeks.5s7vzgi4',
+         #id: 'elijahmeeks.gqd89536',
+         attribution: 'Indicator (1880)',
+         accessToken: L.mapbox.accessToken,
+         detectRetina: true
+         });
 
-    l_bowles = L.mapbox.tileLayer(
-        'elijahmeeks.95vtr2c4',
-        # 'elijahmeeks.36cac3di',
-        L.mapbox.accessToken, {
-        attribution: 'Bowles (1783)',
-        detectRetina: true
-        });
+    l_bowles = L.tileLayer(
+         'https://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png', {
+         tileSize: 256,
+         id: 'elijahmeeks.95vtr2c4',
+         #id: 'elijahmeeks.36cac3di',
+         attribution: 'Bowles (1783)',
+         accessToken: L.mapbox.accessToken,
+         detectRetina: true
+         });
 
-
-    l_taylor = L.mapbox.tileLayer(
-        'elijahmeeks.1pr88bpk',
-        # 'elijahmeeks.7dd6ynaj',
-        L.mapbox.accessToken, {
-        attribution: 'Taylor (1723)',
-        detectRetina: true
-        });
+    l_taylor = L.tileLayer(
+         'https://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png', {
+         tileSize: 256,
+         id: 'elijahmeeks.1pr88bpk',
+         #id: 'elijahmeeks.7dd6ynaj',
+         attribution: 'Taylor (1723)',
+         accessToken: L.mapbox.accessToken,
+         detectRetina: true
+         });

--- a/app/assets/javascripts/backbone/apps/map/show/show_view.js.coffee
+++ b/app/assets/javascripts/backbone/apps/map/show/show_view.js.coffee
@@ -486,13 +486,7 @@
 
     L.mapbox.accessToken = 'pk.eyJ1IjoiZWxpamFobWVla3MiLCJhIjoiYXlPRmNObyJ9.wnIqLHTkEEAVVT-ihW8BjQ'
 
-    # mapbox light basemap, in progress
-    l_mblight = L.tileLayer(
-        'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
-        id: 'elijahmeeks/ck6cspw6d07ne1ipkqy6czvut',
-        attribution: 'Mapbox',
-        accessToken: L.mapbox.accessToken
-        });
+    l_mblight = L.mapbox.styleLayer('mapbox://styles/elijahmeeks/ck6cspw6d07ne1ipkqy6czvut');
 
     # OSM base layer
     l_osm = L.tileLayer(


### PR DESCRIPTION
This PR updates the `mapbox-rails` gem from `1.6.1.1` to `2.3.0` which supports new `styleLayer` API, and loads overlay layers (historical maps) as Leaflet layers, as Mapbox TileLayers don't seem to composite properly w/r/t transparency.